### PR TITLE
docs: Update docs link to latest url

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -45,4 +45,3 @@ Read [Github documentation if you need help](https://help.github.com/en/articles
 * Storage backend version (e.g. for ceph do `ceph -v`):
 * Kubernetes version (use `kubectl version`):
 * Kubernetes cluster type (e.g. Tectonic, GKE, OpenShift):
-* Storage backend status (e.g. for Ceph use `ceph health` in the [Rook Ceph toolbox](https://rook.io/docs/rook/master/ceph-toolbox.html)):

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,4 +36,3 @@ Read [Github documentation if you need help](https://help.github.com/en/articles
 * Storage backend version (e.g. for ceph do `ceph -v`):
 * Kubernetes version (use `kubectl version`):
 * Kubernetes cluster type (e.g. Tectonic, GKE, OpenShift):
-* Storage backend status (e.g. for Ceph use `ceph health` in the [Rook Ceph toolbox](https://rook.io/docs/rook/master/ceph-toolbox.html)):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
+<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
 documentation before submitting a Pull Request!
 Thank you for contributing to Rook! -->
 
@@ -9,10 +9,10 @@ Resolves #
 
 **Checklist:**
 
-- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
+- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
 - [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/cassandra/blob/master/INSTALL.md#skip-ci) for the flag.
 - [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/cassandra/blob/master/INSTALL.md#test-storage-provider).
-- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
+- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
 - [ ] Documentation has been updated, if necessary.
 - [ ] Unit tests have been added, if necessary.
 - [ ] Integration tests have been added, if necessary.

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -23,4 +23,4 @@ jobs:
       - uses: wagoid/commitlint-github-action@v2.0.3
         with:
           configFile: './.commitlintrc.json'
-          helpURL: https://rook.io/docs/rook/master/development-flow.html#commit-structure
+          helpURL: https://rook.io/docs/rook/latest/development-flow.html#commit-structure

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -31,7 +31,7 @@ pull_request_rules:
       - conflict
     actions:
       comment:
-        message: This pull request has merge conflicts that must be resolved before it can be merged. @{{author}} please rebase it. https://rook.io/docs/rook/master/development-flow.html#updating-your-fork
+        message: This pull request has merge conflicts that must be resolved before it can be merged. @{{author}} please rebase it. https://rook.io/docs/rook/latest/development-flow.html#updating-your-fork
 
   # automerge on master only under certain strict conditions
   - name: automerge merge master with specific label and approvals with code change

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Rook is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CNCF
 
 ## Getting Started and Documentation
 
-For installation, deployment, and administration of the Cassandra storage provider, see our [Documentation](https://rook.io/docs/cassandra/master).
+For installation, deployment, and administration of the Cassandra storage provider, see our [Documentation](https://rook.io/docs/cassandra/latest).
 
 ## Contributing
 

--- a/design/README.md
+++ b/design/README.md
@@ -1,3 +1,3 @@
 # Rook Feature Proposal
 
-Please follow the [design section guideline](https://rook.io/docs/rook/master/development-flow.html#design-document).
+Please follow the [design section guideline](https://rook.io/docs/rook/latest/development-flow.html#design-document).


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The readme needs to link to the new latest url instead of the old master url.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/cassandra/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/cassandra/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
