### PR TITLE
docs: Deprecate the cassandra operator

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,5 +1,7 @@
 # Rook
 
+**The Rook Cassandra operator is [deprecated](https://github.com/rook/cassandra#deprecated)**
+
 Rook is an open source **cloud-native storage orchestrator**, providing the platform, framework, and support for a diverse set of storage solutions to natively integrate with cloud-native environments.
 
 Rook turns storage software into self-managing, self-scaling, and self-healing storage services. It does this by automating deployment, bootstrapping, configuration, provisioning, scaling, upgrading, migration, disaster recovery, monitoring, and resource management. Rook uses the facilities provided by the underlying cloud-native container management, scheduling and orchestration platform to perform its duties.

--- a/Documentation/cassandra-cluster-crd.md
+++ b/Documentation/cassandra-cluster-crd.md
@@ -5,6 +5,8 @@ weight: 3000
 
 # Cassandra Cluster CRD
 
+**The Rook Cassandra operator is [deprecated](https://github.com/rook/cassandra#deprecated)**
+
 Cassandra database clusters can be created and configuring using the `clusters.cassandra.rook.io` custom resource definition (CRD).
 
 Please refer to the the [user guide walk-through](quickstart.md) for complete instructions.

--- a/Documentation/cassandra-operator-upgrade.md
+++ b/Documentation/cassandra-operator-upgrade.md
@@ -5,6 +5,8 @@ weight: 6000
 
 # Cassandra Operator Upgrades
 
+**The Rook Cassandra operator is [deprecated](https://github.com/rook/cassandra#deprecated)**
+
 This guide will walk you through the manual steps to upgrade the software in Cassandra Operator from one version to the next. The cassandra operator is made up of two parts:
 
 1. The `Operator` binary that runs as a standalone application, watches the Cassandra Cluster CRD and makes administrative decisions.

--- a/Documentation/common-issues.md
+++ b/Documentation/common-issues.md
@@ -5,6 +5,8 @@ weight: 8000
 
 # Common Issues
 
+**The Rook Cassandra operator is [deprecated](https://github.com/rook/cassandra#deprecated)**
+
 To help troubleshoot your Rook clusters, here are some tips on what information will help solve the issues you might be seeing.
 If after trying the suggestions found on this page and the problem is not resolved, the Rook team is very happy to help you troubleshoot the issues in their Slack channel. Once you have [registered for the Rook Slack](https://slack.rook.io), proceed to the General channel to ask for assistance.
 

--- a/Documentation/development-flow.md
+++ b/Documentation/development-flow.md
@@ -5,6 +5,8 @@ weight: 12000
 
 # Contributing
 
+**The Rook Cassandra operator is [deprecated](https://github.com/rook/cassandra#deprecated)**
+
 Thank you for your time and effort to help us improve Rook! Here are a few steps to get started. If you have any questions,
 don't hesitate to reach out to us on our [Slack](https://Rook-io.slack.com) dev channel.
 

--- a/Documentation/k8s-pre-reqs.md
+++ b/Documentation/k8s-pre-reqs.md
@@ -6,6 +6,8 @@ weight: 1000
 
 # Prerequisites
 
+**The Rook Cassandra operator is [deprecated](https://github.com/rook/cassandra#deprecated)**
+
 Rook can be installed on any existing Kubernetes cluster as long as it meets the minimum version
 and Rook is granted the required privileges (see below for more information).
 

--- a/Documentation/quickstart.md
+++ b/Documentation/quickstart.md
@@ -6,6 +6,8 @@ weight: 2000
 
 # Cassandra Quickstart
 
+**The Rook Cassandra operator is [deprecated](https://github.com/rook/cassandra#deprecated)**
+
 Welcome to Rook! We hope you have a great experience installing the Rook **cloud-native storage orchestrator** platform to enable highly available, durable storage in your Kubernetes cluster.
 
 [Cassandra](http://cassandra.apache.org/) is a highly available, fault tolerant, peer-to-peer NoSQL database featuring lightning fast performance and tunable consistency. It provides massive scalability with no single point of failure.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/rook/cassandra)](https://goreportcard.com/report/github.com/rook/cassandra)
 [![Slack](https://slack.rook.io/badge.svg)](https://slack.rook.io)
 
-# What is Rook?
+# Deprecated
+
+The Rook Cassandra operator has been deprecated due to lack of community support. We recommend deploying Cassandra with the [k8ssandra/cass-operator](https://github.com/k8ssandra/cass-operator/) which is under more active development by the community.
+
+## What is Rook?
 
 Rook is an open source **cloud-native storage orchestrator** for Kubernetes, providing the platform, framework, and support for a diverse set of storage solutions to natively integrate with cloud-native environments.
 
@@ -18,27 +22,6 @@ We plan to continue adding support for other storage systems and environments ba
 
 Rook is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CNCF) as a [graduated](https://www.cncf.io/announcements/2020/10/07/cloud-native-computing-foundation-announces-rook-graduation/) level project. If you are a company that wants to help shape the evolution of technologies that are container-packaged, dynamically-scheduled and microservices-oriented, consider joining the CNCF. For details about who's involved and how Rook plays a role, read the CNCF [announcement](https://www.cncf.io/blog/2018/01/29/cncf-host-rook-project-cloud-native-storage-capabilities).
 
-## Getting Started and Documentation
-
-For installation, deployment, and administration of the Cassandra storage provider, see our [Documentation](https://rook.io/docs/cassandra/latest).
-
-## Contributing
-
-We welcome contributions. See [Contributing](CONTRIBUTING.md) to get started.
-
-## Report a Bug
-
-For filing bugs, suggesting improvements, or requesting new features, please open an [issue](https://github.com/rook/cassandra/issues).
-
-### Reporting Security Vulnerabilities
-
-If you find a vulnerability or a potential vulnerability in Rook please let us know immediately at
-[cncf-rook-security@lists.cncf.io](mailto:cncf-rook-security@lists.cncf.io). We'll send a confirmation email to acknowledge your
-report, and we'll send an additional email when we've identified the issues positively or
-negatively.
-
-For further details, please see the complete [security release process](SECURITY.md).
-
 ## Contact
 
 Please use the following to reach members of the community:
@@ -49,26 +32,15 @@ Please use the following to reach members of the community:
 - Email (general topics): [cncf-rook-info@lists.cncf.io](mailto:cncf-rook-info@lists.cncf.io)
 - Email (security topics): [cncf-rook-security@lists.cncf.io](mailto:cncf-rook-security@lists.cncf.io)
 
-### Community Meeting
-
-A regular community meeting takes place every other [Tuesday at 9:00 AM PT (Pacific Time)](https://zoom.us/j/392602367?pwd=NU1laFZhTWF4MFd6cnRoYzVwbUlSUT09).
-Convert to your [local timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
-
-Any changes to the meeting schedule will be added to the [agenda doc](https://docs.google.com/document/d/1exd8_IG6DkdvyA0eiTtL2z5K2Ra-y68VByUUgwP7I9A/edit?usp=sharing) and posted to [Slack #announcements](https://rook-io.slack.com/messages/C76LLCEE7/) and the [rook-dev mailing list](https://groups.google.com/forum/#!forum/rook-dev).
-
-Anyone who wants to discuss the direction of the project, design and implementation reviews, or general questions with the broader community is welcome and encouraged to join.
-
-- Meeting link: <https://zoom.us/j/392602367?pwd=NU1laFZhTWF4MFd6cnRoYzVwbUlSUT09>
-- [Current agenda and past meeting notes](https://docs.google.com/document/d/1exd8_IG6DkdvyA0eiTtL2z5K2Ra-y68VByUUgwP7I9A/edit?usp=sharing)
-- [Past meeting recordings](https://www.youtube.com/playlist?list=PLP0uDo-ZFnQP6NAgJWAtR9jaRcgqyQKVy)
-
 ## Project Status
+
+**Deprecated**
 
 The status of each storage provider supported by Rook can be found in the [main Rook repo](https://github.com/rook/rook#project-status).
 
 | Name      | Details                                                                                                                                                                                                                                                                                                                | API Group                  | Status |
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------ |
-| Cassandra | [Cassandra](http://cassandra.apache.org/) is a highly available NoSQL database featuring lightning fast performance, tunable consistency and massive scalability. [Scylla](https://www.scylladb.com) is a close-to-the-hardware rewrite of Cassandra in C++, which enables much lower latencies and higher throughput. | cassandra.rook.io/v1alpha1 | Alpha  |
+| Cassandra | [Cassandra](http://cassandra.apache.org/) is a highly available NoSQL database featuring lightning fast performance, tunable consistency and massive scalability. [Scylla](https://www.scylladb.com) is a close-to-the-hardware rewrite of Cassandra in C++, which enables much lower latencies and higher throughput. | cassandra.rook.io/v1alpha1 | [Deprecated](#deprecated)  |
 
 ### Official Releases
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The Rook Cassadra operator has been deprecated due to lack of community support. We recommend deploying Cassandra with the [k8ssandra/cass-operator](https://github.com/k8ssandra/cass-operator/) which is under more active development by the community.

**Which issue is resolved by this Pull Request:**
Resolves #29 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/cassandra/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/cassandra/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
